### PR TITLE
Implement CDP method `Page.bringToFront`

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -482,6 +482,11 @@ impl Tab {
         Ok(self)
     }
 
+    // Pulls focus to this tab
+    pub fn bring_to_front(&self) -> Result<Page::BringToFrontReturnObject> {
+        Ok(self.call_method(Page::BringToFront(None))?)
+    }
+
     pub fn navigate_to(&self, url: &str) -> Result<&Self> {
         let return_object = self.call_method(Navigate {
             url: url.to_string(),


### PR DESCRIPTION
# Changes

- implement `bring_to_front` method for switching tabs - [reference](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-bringToFront)